### PR TITLE
Add FastAPI frontend with Jinja2 templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,62 @@
+from fastapi import FastAPI, Request, Form
+from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
+import school_service as svc
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+
+@app.get("/")
+async def root() -> RedirectResponse:
+    return RedirectResponse(url="/courses")
+
+
+@app.get("/teachers")
+async def get_teachers(request: Request):
+    teachers = svc.list_teachers()
+    return templates.TemplateResponse("teachers.html", {"request": request, "teachers": teachers})
+
+
+@app.get("/courses")
+async def get_courses(request: Request):
+    courses = svc.list_courses()
+    return templates.TemplateResponse("courses.html", {"request": request, "courses": courses})
+
+
+@app.post("/courses/add")
+async def post_course(name: str = Form(...), credits: int = Form(...), teacher_id: int | None = Form(None)):
+    svc.add_course(name, credits, teacher_id)
+    return RedirectResponse("/courses", status_code=303)
+
+
+@app.post("/enroll")
+async def enroll(student_id: int = Form(...), course_id: int = Form(...), semester: str = Form(...)):
+    svc.enroll_student_in_course(student_id, course_id, semester)
+    return RedirectResponse("/courses", status_code=303)
+
+
+@app.get("/progress")
+async def progress(request: Request, student_id: int | None = None, program_id: int | None = None):
+    context = {"request": request, "student_id": student_id, "program_id": program_id}
+    if student_id is not None and program_id is not None:
+        passed, remaining, failed = svc.get_student_progress(student_id, program_id)
+        context.update({"passed": passed, "remaining": remaining, "failed": failed})
+    return templates.TemplateResponse("student_progress.html", context)
+
+
+@app.get("/analytics")
+async def analytics(request: Request):
+    return templates.TemplateResponse("analytics.html", {"request": request})
+
+
+@app.get("/api/analytics/popular-courses")
+async def popular_courses():
+    data = svc.get_most_popular_courses()
+    return [{"name": row["name"], "count": row["cnt"]} for row in data]
+
+
+@app.get("/api/analytics/popular-teachers")
+async def popular_teachers():
+    data = svc.get_most_popular_teachers()
+    return [{"name": row["name"], "count": row["cnt"]} for row in data]

--- a/school_db.py
+++ b/school_db.py
@@ -4,8 +4,10 @@ from pathlib import Path
 DB_NAME = 'school.db'
 
 
-def get_connection(db_path: str | Path = DB_NAME) -> sqlite3.Connection:
+def get_connection(db_path: str | Path | None = None) -> sqlite3.Connection:
     """Return a SQLite connection with Row factory."""
+    if db_path is None:
+        db_path = DB_NAME
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     return conn

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Analytics</h1>
+<canvas id="coursesChart" width="400" height="200"></canvas>
+<canvas id="teachersChart" width="400" height="200"></canvas>
+<script>
+async function loadCharts() {
+  const coursesResp = await fetch('/api/analytics/popular-courses');
+  const coursesData = await coursesResp.json();
+  const courseLabels = coursesData.map(c => c.name);
+  const courseCounts = coursesData.map(c => c.count);
+
+  new Chart(document.getElementById('coursesChart'), {
+    type: 'bar',
+    data: {
+      labels: courseLabels,
+      datasets: [{
+        label: 'Popular Courses',
+        data: courseCounts,
+        backgroundColor: 'rgba(54, 162, 235, 0.2)',
+        borderColor: 'rgba(54, 162, 235, 1)',
+        borderWidth: 1
+      }]
+    }
+  });
+
+  const teachersResp = await fetch('/api/analytics/popular-teachers');
+  const teachersData = await teachersResp.json();
+  const teacherLabels = teachersData.map(t => t.name);
+  const teacherCounts = teachersData.map(t => t.count);
+
+  new Chart(document.getElementById('teachersChart'), {
+    type: 'bar',
+    data: {
+      labels: teacherLabels,
+      datasets: [{
+        label: 'Popular Teachers',
+        data: teacherCounts,
+        backgroundColor: 'rgba(255, 99, 132, 0.2)',
+        borderColor: 'rgba(255, 99, 132, 1)',
+        borderWidth: 1
+      }]
+    }
+  });
+}
+loadCharts();
+</script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>{{ title or 'Sample Agenda' }}</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<nav>
+    <a href="/teachers">Teachers</a> |
+    <a href="/courses">Courses</a> |
+    <a href="/progress">Student Progress</a> |
+    <a href="/analytics">Analytics</a>
+</nav>
+<hr>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Courses</h1>
+<ul>
+{% for c in courses %}
+  <li>{{ c['name'] }} ({{ c['credits'] }} credits) - {{ c['teacher_name'] or 'No teacher' }}</li>
+{% endfor %}
+</ul>
+
+<h2>Add Course</h2>
+<form action="/courses/add" method="post">
+  <input type="text" name="name" placeholder="Name" required>
+  <input type="number" name="credits" placeholder="Credits" required>
+  <input type="number" name="teacher_id" placeholder="Teacher ID">
+  <button type="submit">Add</button>
+</form>
+
+<h2>Enroll Student</h2>
+<form action="/enroll" method="post">
+  <input type="number" name="student_id" placeholder="Student ID" required>
+  <input type="number" name="course_id" placeholder="Course ID" required>
+  <input type="text" name="semester" placeholder="Semester" required>
+  <button type="submit">Enroll</button>
+</form>
+{% endblock %}

--- a/templates/student_progress.html
+++ b/templates/student_progress.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Student Progress</h1>
+<form method="get">
+  <input type="number" name="student_id" placeholder="Student ID" value="{{ student_id or '' }}" required>
+  <input type="number" name="program_id" placeholder="Program ID" value="{{ program_id or '' }}" required>
+  <button type="submit">Check</button>
+</form>
+
+{% if passed is defined %}
+<ul>
+  <li>Passed: {{ passed }}</li>
+  <li>Remaining: {{ remaining }}</li>
+  <li>Failed Attempts: {{ failed }}</li>
+</ul>
+{% endif %}
+{% endblock %}

--- a/templates/teachers.html
+++ b/templates/teachers.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Teachers</h1>
+<ul>
+{% for t in teachers %}
+  <li>{{ t['first_name'] }} {{ t['last_name'] }} ({{ t['email'] or '' }})</li>
+{% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Serve teachers, courses, student progress, and analytics pages using FastAPI and Jinja2 templates
- Provide forms to add courses and enroll students, linked to existing service logic
- Add JSON endpoints for analytics data and dynamic DB selection in connection helper

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e123cee8832484e8dd25d2bf4c2b