### PR TITLE
Add FastAPI frontend with Jinja2 templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,194 @@
+from fastapi import FastAPI, Request, Form
+from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
+import school_service as svc
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+
+@app.get("/")
+async def root() -> RedirectResponse:
+    return RedirectResponse(url="/courses")
+
+
+@app.get("/teachers")
+async def get_teachers(request: Request):
+    teachers = svc.list_teachers()
+    return templates.TemplateResponse("teachers.html", {"request": request, "teachers": teachers})
+
+
+@app.post("/teachers/add")
+async def add_teacher(
+    first_name: str = Form(...),
+    last_name: str = Form(...),
+    email: str | None = Form(None),
+):
+    svc.add_teacher(first_name, last_name, email)
+    return RedirectResponse("/teachers", status_code=303)
+
+
+@app.get("/teachers/{teacher_id}")
+async def teacher_detail(request: Request, teacher_id: int):
+    teacher = svc.get_teacher(teacher_id)
+    courses = svc.get_teacher_courses(teacher_id)
+    students = svc.get_teacher_students(teacher_id)
+    evaluations = svc.get_teacher_evaluations(teacher_id)
+    context = {
+        "request": request,
+        "teacher": teacher,
+        "courses": courses,
+        "students": students,
+        "evaluations": evaluations,
+    }
+    return templates.TemplateResponse("teacher_detail.html", context)
+
+
+@app.get("/teachers/{teacher_id}/edit")
+async def edit_teacher_form(request: Request, teacher_id: int):
+    teacher = svc.get_teacher(teacher_id)
+    return templates.TemplateResponse("teacher_edit.html", {"request": request, "teacher": teacher})
+
+
+@app.post("/teachers/{teacher_id}/edit")
+async def edit_teacher(
+    teacher_id: int,
+    first_name: str = Form(...),
+    last_name: str = Form(...),
+    email: str | None = Form(None),
+):
+    svc.update_teacher(teacher_id, first_name, last_name, email)
+    return RedirectResponse(f"/teachers/{teacher_id}", status_code=303)
+
+
+@app.post("/teachers/{teacher_id}/delete")
+async def delete_teacher(teacher_id: int):
+    svc.delete_teacher(teacher_id)
+    return RedirectResponse("/teachers", status_code=303)
+
+
+@app.get("/teachers/{teacher_id}/courses/{course_id}/grades")
+async def course_grades(request: Request, teacher_id: int, course_id: int):
+    enrollments = svc.get_enrollments_for_course(course_id)
+    course = next((c for c in svc.get_teacher_courses(teacher_id) if c["id"] == course_id), None)
+    context = {
+        "request": request,
+        "enrollments": enrollments,
+        "course": course,
+        "teacher_id": teacher_id,
+    }
+    return templates.TemplateResponse("course_grades.html", context)
+
+
+@app.post("/teachers/{teacher_id}/courses/{course_id}/grades")
+async def post_course_grade(
+    teacher_id: int,
+    course_id: int,
+    enrollment_id: int = Form(...),
+    grade: str = Form(...),
+):
+    svc.record_grade(enrollment_id, grade, "completed")
+    return RedirectResponse(
+        f"/teachers/{teacher_id}/courses/{course_id}/grades", status_code=303
+    )
+
+
+@app.get("/students")
+async def get_students(request: Request):
+    students = svc.list_students()
+    return templates.TemplateResponse("students.html", {"request": request, "students": students})
+
+
+@app.post("/students/add")
+async def add_student(
+    first_name: str = Form(...),
+    last_name: str = Form(...),
+    student_number: str = Form(...),
+    email: str | None = Form(None),
+):
+    svc.add_student(first_name, last_name, student_number, email)
+    return RedirectResponse("/students", status_code=303)
+
+
+@app.get("/students/{student_id}/edit")
+async def edit_student_form(request: Request, student_id: int):
+    student = svc.get_student(student_id)
+    return templates.TemplateResponse("student_edit.html", {"request": request, "student": student})
+
+
+@app.post("/students/{student_id}/edit")
+async def edit_student(
+    student_id: int,
+    first_name: str = Form(...),
+    last_name: str = Form(...),
+    student_number: str = Form(...),
+    email: str | None = Form(None),
+):
+    svc.update_student(student_id, first_name, last_name, student_number, email)
+    return RedirectResponse("/students", status_code=303)
+
+
+@app.post("/students/{student_id}/delete")
+async def delete_student(student_id: int):
+    svc.delete_student(student_id)
+    return RedirectResponse("/students", status_code=303)
+
+
+@app.get("/students/{student_id}/enrollments")
+async def student_enrollments(request: Request, student_id: int):
+    student = svc.get_student(student_id)
+    enrollments = svc.get_student_enrollments(student_id)
+    context = {"request": request, "student": student, "enrollments": enrollments}
+    return templates.TemplateResponse("student_enrollments.html", context)
+
+
+@app.get("/students/{student_id}/grades")
+async def student_grades(request: Request, student_id: int):
+    student = svc.get_student(student_id)
+    grades = svc.get_student_grades(student_id)
+    context = {"request": request, "student": student, "grades": grades}
+    return templates.TemplateResponse("student_grades.html", context)
+
+
+@app.get("/courses")
+async def get_courses(request: Request):
+    courses = svc.list_courses()
+    return templates.TemplateResponse("courses.html", {"request": request, "courses": courses})
+
+
+@app.post("/courses/add")
+async def post_course(name: str = Form(...), credits: int = Form(...), teacher_id: int | None = Form(None)):
+    svc.add_course(name, credits, teacher_id)
+    return RedirectResponse("/courses", status_code=303)
+
+
+@app.post("/enroll")
+async def enroll(student_id: int = Form(...), course_id: int = Form(...), semester: str = Form(...)):
+    svc.enroll_student_in_course(student_id, course_id, semester)
+    return RedirectResponse("/courses", status_code=303)
+
+
+@app.get("/progress")
+async def progress(request: Request, student_id: int | None = None, program_id: int | None = None):
+    context = {"request": request, "student_id": student_id, "program_id": program_id}
+    if student_id is not None and program_id is not None:
+        passed, remaining, failed = svc.get_student_progress(student_id, program_id)
+        context.update({"passed": passed, "remaining": remaining, "failed": failed})
+    return templates.TemplateResponse("student_progress.html", context)
+
+
+@app.get("/analytics")
+async def analytics(request: Request):
+    return templates.TemplateResponse("analytics.html", {"request": request})
+
+
+@app.get("/api/analytics/popular-courses")
+async def popular_courses():
+    data = svc.get_most_popular_courses()
+    return [{"name": row["name"], "count": row["cnt"]} for row in data]
+
+
+@app.get("/api/analytics/popular-teachers")
+async def popular_teachers():
+    data = svc.get_most_popular_teachers()
+    return [{"name": row["name"], "count": row["cnt"]} for row in data]

--- a/school_db.py
+++ b/school_db.py
@@ -4,8 +4,10 @@ from pathlib import Path
 DB_NAME = 'school.db'
 
 
-def get_connection(db_path: str | Path = DB_NAME) -> sqlite3.Connection:
+def get_connection(db_path: str | Path | None = None) -> sqlite3.Connection:
     """Return a SQLite connection with Row factory."""
+    if db_path is None:
+        db_path = DB_NAME
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     return conn

--- a/school_service.py
+++ b/school_service.py
@@ -26,6 +26,88 @@ def list_teachers() -> List[sqlite3.Row]:
     return cur.fetchall()
 
 
+def get_teacher(teacher_id: int) -> sqlite3.Row | None:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM teacher WHERE id = ?", (teacher_id,))
+    return cur.fetchone()
+
+
+def update_teacher(teacher_id: int, first_name: str, last_name: str, email: str | None) -> None:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE teacher SET first_name = ?, last_name = ?, email = ? WHERE id = ?",
+        (first_name, last_name, email, teacher_id),
+    )
+    conn.commit()
+
+
+def delete_teacher(teacher_id: int) -> None:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM teacher WHERE id = ?", (teacher_id,))
+    conn.commit()
+
+
+def get_teacher_courses(teacher_id: int) -> List[sqlite3.Row]:
+    conn = get_connection()
+    cur = conn.execute(
+        "SELECT * FROM course WHERE teacher_id = ? ORDER BY name",
+        (teacher_id,),
+    )
+    return cur.fetchall()
+
+
+def get_teacher_students(teacher_id: int) -> List[sqlite3.Row]:
+    conn = get_connection()
+    cur = conn.execute(
+        """
+        SELECT DISTINCT s.*
+        FROM student s
+        JOIN enrollment e ON s.id = e.student_id
+        JOIN course c ON e.course_id = c.id
+        WHERE c.teacher_id = ?
+        ORDER BY s.last_name, s.first_name
+        """,
+        (teacher_id,),
+    )
+    return cur.fetchall()
+
+
+def get_teacher_evaluations(teacher_id: int) -> List[sqlite3.Row]:
+    conn = get_connection()
+    cur = conn.execute(
+        """
+        SELECT s.first_name || ' ' || s.last_name AS student_name,
+               c.name AS course_name,
+               e.grade
+        FROM enrollment e
+        JOIN student s ON e.student_id = s.id
+        JOIN course c ON e.course_id = c.id
+        WHERE c.teacher_id = ? AND e.grade IS NOT NULL
+        ORDER BY c.name, student_name
+        """,
+        (teacher_id,),
+    )
+    return cur.fetchall()
+
+
+def get_enrollments_for_course(course_id: int) -> List[sqlite3.Row]:
+    conn = get_connection()
+    cur = conn.execute(
+        """
+        SELECT e.id, s.first_name || ' ' || s.last_name AS student_name,
+               e.grade, e.status
+        FROM enrollment e
+        JOIN student s ON e.student_id = s.id
+        WHERE e.course_id = ?
+        ORDER BY student_name
+        """,
+        (course_id,),
+    )
+    return cur.fetchall()
+
+
 def add_course(name: str, credits: int, teacher_id: int | None) -> int:
     conn = get_connection()
     init_db(conn)
@@ -81,6 +163,65 @@ def add_student(first_name: str, last_name: str, student_number: str, email: str
 def list_students() -> List[sqlite3.Row]:
     conn = get_connection()
     cur = conn.execute("SELECT * FROM student ORDER BY last_name, first_name")
+    return cur.fetchall()
+
+
+def get_student(student_id: int) -> sqlite3.Row | None:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM student WHERE id = ?", (student_id,))
+    return cur.fetchone()
+
+
+def update_student(
+    student_id: int,
+    first_name: str,
+    last_name: str,
+    student_number: str,
+    email: str | None,
+) -> None:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE student SET first_name = ?, last_name = ?, student_number = ?, email = ? WHERE id = ?",
+        (first_name, last_name, student_number, email, student_id),
+    )
+    conn.commit()
+
+
+def delete_student(student_id: int) -> None:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM student WHERE id = ?", (student_id,))
+    conn.commit()
+
+
+def get_student_enrollments(student_id: int) -> List[sqlite3.Row]:
+    conn = get_connection()
+    cur = conn.execute(
+        """
+        SELECT e.*, c.name AS course_name
+        FROM enrollment e
+        JOIN course c ON e.course_id = c.id
+        WHERE e.student_id = ?
+        ORDER BY c.name
+        """,
+        (student_id,),
+    )
+    return cur.fetchall()
+
+
+def get_student_grades(student_id: int) -> List[sqlite3.Row]:
+    conn = get_connection()
+    cur = conn.execute(
+        """
+        SELECT e.*, c.name AS course_name
+        FROM enrollment e
+        JOIN course c ON e.course_id = c.id
+        WHERE e.student_id = ? AND e.grade IS NOT NULL
+        ORDER BY c.name
+        """,
+        (student_id,),
+    )
     return cur.fetchall()
 
 

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Analytics</h1>
+<canvas id="coursesChart" width="400" height="200"></canvas>
+<canvas id="teachersChart" width="400" height="200"></canvas>
+<script>
+async function loadCharts() {
+  const coursesResp = await fetch('/api/analytics/popular-courses');
+  const coursesData = await coursesResp.json();
+  const courseLabels = coursesData.map(c => c.name);
+  const courseCounts = coursesData.map(c => c.count);
+
+  new Chart(document.getElementById('coursesChart'), {
+    type: 'bar',
+    data: {
+      labels: courseLabels,
+      datasets: [{
+        label: 'Popular Courses',
+        data: courseCounts,
+        backgroundColor: 'rgba(54, 162, 235, 0.2)',
+        borderColor: 'rgba(54, 162, 235, 1)',
+        borderWidth: 1
+      }]
+    }
+  });
+
+  const teachersResp = await fetch('/api/analytics/popular-teachers');
+  const teachersData = await teachersResp.json();
+  const teacherLabels = teachersData.map(t => t.name);
+  const teacherCounts = teachersData.map(t => t.count);
+
+  new Chart(document.getElementById('teachersChart'), {
+    type: 'bar',
+    data: {
+      labels: teacherLabels,
+      datasets: [{
+        label: 'Popular Teachers',
+        data: teacherCounts,
+        backgroundColor: 'rgba(255, 99, 132, 0.2)',
+        borderColor: 'rgba(255, 99, 132, 1)',
+        borderWidth: 1
+      }]
+    }
+  });
+}
+loadCharts();
+</script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>{{ title or 'Sample Agenda' }}</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<nav>
+    <a href="/teachers">Teachers</a> |
+    <a href="/students">Students</a> |
+    <a href="/courses">Courses</a> |
+    <a href="/progress">Student Progress</a> |
+    <a href="/analytics">Analytics</a>
+</nav>
+<hr>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/course_grades.html
+++ b/templates/course_grades.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ course['name'] }} - Grades</h1>
+<ul>
+{% for e in enrollments %}
+  <li>
+    {{ e['student_name'] }}
+    <form method="post" style="display:inline">
+      <input type="hidden" name="enrollment_id" value="{{ e['id'] }}">
+      <input name="grade" value="{{ e['grade'] or '' }}">
+      <button type="submit">Save</button>
+    </form>
+  </li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Courses</h1>
+<ul>
+{% for c in courses %}
+  <li>{{ c['name'] }} ({{ c['credits'] }} credits) - {{ c['teacher_name'] or 'No teacher' }}</li>
+{% endfor %}
+</ul>
+
+<h2>Add Course</h2>
+<form action="/courses/add" method="post">
+  <input type="text" name="name" placeholder="Name" required>
+  <input type="number" name="credits" placeholder="Credits" required>
+  <input type="number" name="teacher_id" placeholder="Teacher ID">
+  <button type="submit">Add</button>
+</form>
+
+<h2>Enroll Student</h2>
+<form action="/enroll" method="post">
+  <input type="number" name="student_id" placeholder="Student ID" required>
+  <input type="number" name="course_id" placeholder="Course ID" required>
+  <input type="text" name="semester" placeholder="Semester" required>
+  <button type="submit">Enroll</button>
+</form>
+{% endblock %}

--- a/templates/student_edit.html
+++ b/templates/student_edit.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Student</h1>
+<form method="post">
+  <input name="first_name" value="{{ student['first_name'] }}">
+  <input name="last_name" value="{{ student['last_name'] }}">
+  <input name="student_number" value="{{ student['student_number'] }}">
+  <input name="email" value="{{ student['email'] or '' }}">
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/student_enrollments.html
+++ b/templates/student_enrollments.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ student['first_name'] }} {{ student['last_name'] }} - Enrollments</h1>
+<ul>
+{% for e in enrollments %}
+  <li>{{ e['course_name'] }} ({{ e['semester'] }}) - {{ e['status'] }}{% if e['grade'] %} Grade: {{ e['grade'] }}{% endif %}</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/student_grades.html
+++ b/templates/student_grades.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ student['first_name'] }} {{ student['last_name'] }} - Grades</h1>
+<ul>
+{% for g in grades %}
+  <li>{{ g['course_name'] }}: {{ g['grade'] }} ({{ g['semester'] }})</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/student_progress.html
+++ b/templates/student_progress.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Student Progress</h1>
+<form method="get">
+  <input type="number" name="student_id" placeholder="Student ID" value="{{ student_id or '' }}" required>
+  <input type="number" name="program_id" placeholder="Program ID" value="{{ program_id or '' }}" required>
+  <button type="submit">Check</button>
+</form>
+
+{% if passed is defined %}
+<ul>
+  <li>Passed: {{ passed }}</li>
+  <li>Remaining: {{ remaining }}</li>
+  <li>Failed Attempts: {{ failed }}</li>
+</ul>
+{% endif %}
+{% endblock %}

--- a/templates/students.html
+++ b/templates/students.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Students</h1>
+<form method="post" action="/students/add">
+  <input name="first_name" placeholder="First name">
+  <input name="last_name" placeholder="Last name">
+  <input name="student_number" placeholder="Student number">
+  <input name="email" placeholder="Email">
+  <button type="submit">Add</button>
+</form>
+<ul>
+{% for s in students %}
+  <li>
+    {{ s['first_name'] }} {{ s['last_name'] }} ({{ s['student_number'] }})
+    <a href="/students/{{ s['id'] }}/edit">Edit</a>
+    <form method="post" action="/students/{{ s['id'] }}/delete" style="display:inline">
+      <button type="submit">Delete</button>
+    </form>
+    <a href="/students/{{ s['id'] }}/enrollments">Enrollments</a>
+    <a href="/progress?student_id={{ s['id'] }}">Progress</a>
+    <a href="/students/{{ s['id'] }}/grades">Grades</a>
+  </li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/teacher_detail.html
+++ b/templates/teacher_detail.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ teacher['first_name'] }} {{ teacher['last_name'] }}</h1>
+<h2>Courses</h2>
+<ul>
+{% for c in courses %}
+  <li><a href="/teachers/{{ teacher['id'] }}/courses/{{ c['id'] }}/grades">{{ c['name'] }}</a></li>
+{% endfor %}
+</ul>
+<h2>Students</h2>
+<ul>
+{% for s in students %}
+  <li>{{ s['first_name'] }} {{ s['last_name'] }}</li>
+{% endfor %}
+</ul>
+<h2>Evaluations</h2>
+<ul>
+{% for e in evaluations %}
+  <li>{{ e['course_name'] }} - {{ e['student_name'] }}: {{ e['grade'] }}</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/teacher_edit.html
+++ b/templates/teacher_edit.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Teacher</h1>
+<form method="post">
+  <input name="first_name" value="{{ teacher['first_name'] }}">
+  <input name="last_name" value="{{ teacher['last_name'] }}">
+  <input name="email" value="{{ teacher['email'] or '' }}">
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/teachers.html
+++ b/templates/teachers.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Teachers</h1>
+<form method="post" action="/teachers/add">
+  <input name="first_name" placeholder="First name">
+  <input name="last_name" placeholder="Last name">
+  <input name="email" placeholder="Email">
+  <button type="submit">Add</button>
+</form>
+<ul>
+{% for t in teachers %}
+  <li>
+    <a href="/teachers/{{ t['id'] }}">{{ t['first_name'] }} {{ t['last_name'] }}</a>
+    ({{ t['email'] or '' }})
+    <a href="/teachers/{{ t['id'] }}/edit">Edit</a>
+    <form method="post" action="/teachers/{{ t['id'] }}/delete" style="display:inline">
+      <button type="submit">Delete</button>
+    </form>
+  </li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -35,6 +35,22 @@ class ServiceTest(unittest.TestCase):
         passed, remaining, failed = svc.get_student_progress(s_id, p_id)
         self.assertEqual((passed, remaining, failed), (1, 0, 0))
 
+    def test_student_crud_and_queries(self):
+        s_id = svc.add_student("Bob", "Green", "S100", None)
+        svc.update_student(s_id, "Bobby", "Green", "S100", "bob@example.com")
+        student = svc.get_student(s_id)
+        self.assertEqual(student["first_name"], "Bobby")
+        t_id = svc.add_teacher("Teacher", "One", None)
+        c_id = svc.add_course("Course", 3, t_id)
+        e_id = svc.enroll_student_in_course(s_id, c_id, "2023")
+        svc.record_grade(e_id, "A", "completed")
+        enrollments = svc.get_student_enrollments(s_id)
+        self.assertEqual(len(enrollments), 1)
+        grades = svc.get_student_grades(s_id)
+        self.assertEqual(grades[0]["grade"], "A")
+        svc.delete_student(s_id)
+        self.assertEqual(len(svc.list_students()), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Serve teachers, courses, student progress, and analytics pages using FastAPI and Jinja2 templates
- Provide forms to add courses and enroll students, linked to existing service logic
- Add JSON endpoints for analytics data and dynamic DB selection in connection helper
- Manage teachers and students with add/edit/delete, show related courses/enrollments, and allow grading

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e123cee8832484e8dd25d2bf4c2b