### PR TITLE
Enhance templates with Bootstrap styling

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,10 +3,12 @@
 <head>
     <meta charset="utf-8" />
     <title>{{ title or 'Sample Agenda' }}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
-<nav>
+<div class="container mt-4">
+<nav class="mb-3">
     <a href="/teachers">Teachers</a> |
     <a href="/students">Students</a> |
     <a href="/courses">Courses</a> |
@@ -15,5 +17,6 @@
 </nav>
 <hr>
 {% block content %}{% endblock %}
+</div>
 </body>
 </html>

--- a/templates/course_grades.html
+++ b/templates/course_grades.html
@@ -1,14 +1,14 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>{{ course['name'] }} - Grades</h1>
-<ul>
+<ul class="list-group">
 {% for e in enrollments %}
-  <li>
+  <li class="list-group-item">
     {{ e['student_name'] }}
-    <form method="post" style="display:inline">
+    <form method="post" class="d-inline-flex align-items-center gap-2">
       <input type="hidden" name="enrollment_id" value="{{ e['id'] }}">
-      <input name="grade" value="{{ e['grade'] or '' }}">
-      <button type="submit">Save</button>
+      <input name="grade" value="{{ e['grade'] or '' }}" class="form-control">
+      <button type="submit" class="btn btn-primary btn-sm">Save</button>
     </form>
   </li>
 {% endfor %}

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -1,25 +1,41 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Courses</h1>
-<ul>
+<ul class="list-group">
 {% for c in courses %}
-  <li>{{ c['name'] }} ({{ c['credits'] }} credits) - {{ c['teacher_name'] or 'No teacher' }}</li>
+  <li class="list-group-item">{{ c['name'] }} ({{ c['credits'] }} credits) - {{ c['teacher_name'] or 'No teacher' }}</li>
 {% endfor %}
 </ul>
 
-<h2>Add Course</h2>
-<form action="/courses/add" method="post">
-  <input type="text" name="name" placeholder="Name" required>
-  <input type="number" name="credits" placeholder="Credits" required>
-  <input type="number" name="teacher_id" placeholder="Teacher ID">
-  <button type="submit">Add</button>
+<h2 class="mt-4">Add Course</h2>
+<form action="/courses/add" method="post" class="row g-3">
+  <div class="col-md">
+    <input type="text" name="name" placeholder="Name" required class="form-control">
+  </div>
+  <div class="col-md">
+    <input type="number" name="credits" placeholder="Credits" required class="form-control">
+  </div>
+  <div class="col-md">
+    <input type="number" name="teacher_id" placeholder="Teacher ID" class="form-control">
+  </div>
+  <div class="col-md-auto">
+    <button type="submit" class="btn btn-primary">Add</button>
+  </div>
 </form>
 
-<h2>Enroll Student</h2>
-<form action="/enroll" method="post">
-  <input type="number" name="student_id" placeholder="Student ID" required>
-  <input type="number" name="course_id" placeholder="Course ID" required>
-  <input type="text" name="semester" placeholder="Semester" required>
-  <button type="submit">Enroll</button>
+<h2 class="mt-4">Enroll Student</h2>
+<form action="/enroll" method="post" class="row g-3">
+  <div class="col-md">
+    <input type="number" name="student_id" placeholder="Student ID" required class="form-control">
+  </div>
+  <div class="col-md">
+    <input type="number" name="course_id" placeholder="Course ID" required class="form-control">
+  </div>
+  <div class="col-md">
+    <input type="text" name="semester" placeholder="Semester" required class="form-control">
+  </div>
+  <div class="col-md-auto">
+    <button type="submit" class="btn btn-primary">Enroll</button>
+  </div>
 </form>
 {% endblock %}

--- a/templates/student_edit.html
+++ b/templates/student_edit.html
@@ -1,11 +1,21 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Student</h1>
-<form method="post">
-  <input name="first_name" value="{{ student['first_name'] }}">
-  <input name="last_name" value="{{ student['last_name'] }}">
-  <input name="student_number" value="{{ student['student_number'] }}">
-  <input name="email" value="{{ student['email'] or '' }}">
-  <button type="submit">Save</button>
+<form method="post" class="row g-3">
+    <div class="col-md">
+        <input name="first_name" value="{{ student['first_name'] }}" class="form-control">
+    </div>
+    <div class="col-md">
+        <input name="last_name" value="{{ student['last_name'] }}" class="form-control">
+    </div>
+    <div class="col-md">
+        <input name="student_number" value="{{ student['student_number'] }}" class="form-control">
+    </div>
+    <div class="col-md">
+        <input name="email" value="{{ student['email'] or '' }}" class="form-control">
+    </div>
+    <div class="col-md-auto">
+        <button type="submit" class="btn btn-primary">Save</button>
+    </div>
 </form>
 {% endblock %}

--- a/templates/student_progress.html
+++ b/templates/student_progress.html
@@ -1,10 +1,16 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Student Progress</h1>
-<form method="get">
-  <input type="number" name="student_id" placeholder="Student ID" value="{{ student_id or '' }}" required>
-  <input type="number" name="program_id" placeholder="Program ID" value="{{ program_id or '' }}" required>
-  <button type="submit">Check</button>
+<form method="get" class="row g-3">
+  <div class="col-md">
+    <input type="number" name="student_id" placeholder="Student ID" value="{{ student_id or '' }}" required class="form-control">
+  </div>
+  <div class="col-md">
+    <input type="number" name="program_id" placeholder="Program ID" value="{{ program_id or '' }}" required class="form-control">
+  </div>
+  <div class="col-md-auto">
+    <button type="submit" class="btn btn-primary">Check</button>
+  </div>
 </form>
 
 {% if passed is defined %}

--- a/templates/students.html
+++ b/templates/students.html
@@ -1,24 +1,34 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Students</h1>
-<form method="post" action="/students/add">
-  <input name="first_name" placeholder="First name">
-  <input name="last_name" placeholder="Last name">
-  <input name="student_number" placeholder="Student number">
-  <input name="email" placeholder="Email">
-  <button type="submit">Add</button>
+<form method="post" action="/students/add" class="row g-3">
+  <div class="col-md">
+    <input name="first_name" placeholder="First name" class="form-control">
+  </div>
+  <div class="col-md">
+    <input name="last_name" placeholder="Last name" class="form-control">
+  </div>
+  <div class="col-md">
+    <input name="student_number" placeholder="Student number" class="form-control">
+  </div>
+  <div class="col-md">
+    <input name="email" placeholder="Email" class="form-control">
+  </div>
+  <div class="col-md-auto">
+    <button type="submit" class="btn btn-primary">Add</button>
+  </div>
 </form>
-<ul>
+<ul class="list-group mt-3">
 {% for s in students %}
-  <li>
+  <li class="list-group-item">
     {{ s['first_name'] }} {{ s['last_name'] }} ({{ s['student_number'] }})
-    <a href="/students/{{ s['id'] }}/edit">Edit</a>
-    <form method="post" action="/students/{{ s['id'] }}/delete" style="display:inline">
-      <button type="submit">Delete</button>
+    <a href="/students/{{ s['id'] }}/edit" class="btn btn-secondary btn-sm ms-2">Edit</a>
+    <form method="post" action="/students/{{ s['id'] }}/delete" class="d-inline">
+      <button type="submit" class="btn btn-danger btn-sm">Delete</button>
     </form>
-    <a href="/students/{{ s['id'] }}/enrollments">Enrollments</a>
-    <a href="/progress?student_id={{ s['id'] }}">Progress</a>
-    <a href="/students/{{ s['id'] }}/grades">Grades</a>
+    <a href="/students/{{ s['id'] }}/enrollments" class="btn btn-link btn-sm">Enrollments</a>
+    <a href="/progress?student_id={{ s['id'] }}" class="btn btn-link btn-sm">Progress</a>
+    <a href="/students/{{ s['id'] }}/grades" class="btn btn-link btn-sm">Grades</a>
   </li>
 {% endfor %}
 </ul>

--- a/templates/teacher_edit.html
+++ b/templates/teacher_edit.html
@@ -1,10 +1,18 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Teacher</h1>
-<form method="post">
-  <input name="first_name" value="{{ teacher['first_name'] }}">
-  <input name="last_name" value="{{ teacher['last_name'] }}">
-  <input name="email" value="{{ teacher['email'] or '' }}">
-  <button type="submit">Save</button>
+<form method="post" class="row g-3">
+    <div class="col-md">
+        <input name="first_name" value="{{ teacher['first_name'] }}" class="form-control">
+    </div>
+    <div class="col-md">
+        <input name="last_name" value="{{ teacher['last_name'] }}" class="form-control">
+    </div>
+    <div class="col-md">
+        <input name="email" value="{{ teacher['email'] or '' }}" class="form-control">
+    </div>
+    <div class="col-md-auto">
+        <button type="submit" class="btn btn-primary">Save</button>
+    </div>
 </form>
 {% endblock %}

--- a/templates/teachers.html
+++ b/templates/teachers.html
@@ -1,20 +1,28 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Teachers</h1>
-<form method="post" action="/teachers/add">
-  <input name="first_name" placeholder="First name">
-  <input name="last_name" placeholder="Last name">
-  <input name="email" placeholder="Email">
-  <button type="submit">Add</button>
+<form method="post" action="/teachers/add" class="row g-3">
+  <div class="col-md">
+    <input name="first_name" placeholder="First name" class="form-control">
+  </div>
+  <div class="col-md">
+    <input name="last_name" placeholder="Last name" class="form-control">
+  </div>
+  <div class="col-md">
+    <input name="email" placeholder="Email" class="form-control">
+  </div>
+  <div class="col-md-auto">
+    <button type="submit" class="btn btn-primary">Add</button>
+  </div>
 </form>
-<ul>
+<ul class="list-group mt-3">
 {% for t in teachers %}
-  <li>
+  <li class="list-group-item">
     <a href="/teachers/{{ t['id'] }}">{{ t['first_name'] }} {{ t['last_name'] }}</a>
     ({{ t['email'] or '' }})
-    <a href="/teachers/{{ t['id'] }}/edit">Edit</a>
-    <form method="post" action="/teachers/{{ t['id'] }}/delete" style="display:inline">
-      <button type="submit">Delete</button>
+    <a href="/teachers/{{ t['id'] }}/edit" class="btn btn-secondary btn-sm ms-2">Edit</a>
+    <form method="post" action="/teachers/{{ t['id'] }}/delete" class="d-inline">
+      <button type="submit" class="btn btn-danger btn-sm">Delete</button>
     </form>
   </li>
 {% endfor %}


### PR DESCRIPTION
## Summary
- Include Bootstrap CDN in base layout and wrap content in a responsive container
- Convert teacher, student, and other templates to use Bootstrap grid, form, and button classes

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c700b768a483248449e1e0794d6ecd