### PR TITLE
Use tables for teacher and student lists

### DIFF
--- a/templates/students.html
+++ b/templates/students.html
@@ -18,18 +18,30 @@
     <button type="submit" class="btn btn-primary">Add</button>
   </div>
 </form>
-<ul class="list-group mt-3">
-{% for s in students %}
-  <li class="list-group-item">
-    {{ s['first_name'] }} {{ s['last_name'] }} ({{ s['student_number'] }})
-    <a href="/students/{{ s['id'] }}/edit" class="btn btn-secondary btn-sm ms-2">Edit</a>
-    <form method="post" action="/students/{{ s['id'] }}/delete" class="d-inline">
-      <button type="submit" class="btn btn-danger btn-sm">Delete</button>
-    </form>
-    <a href="/students/{{ s['id'] }}/enrollments" class="btn btn-link btn-sm">Enrollments</a>
-    <a href="/progress?student_id={{ s['id'] }}" class="btn btn-link btn-sm">Progress</a>
-    <a href="/students/{{ s['id'] }}/grades" class="btn btn-link btn-sm">Grades</a>
-  </li>
-{% endfor %}
-</ul>
+<table class="table table-striped mt-3">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Email</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for s in students %}
+    <tr>
+      <td>{{ s['first_name'] }} {{ s['last_name'] }} ({{ s['student_number'] }})</td>
+      <td>{{ s['email'] }}</td>
+      <td>
+        <a href="/students/{{ s['id'] }}/edit" class="btn btn-secondary btn-sm">Edit</a>
+        <form method="post" action="/students/{{ s['id'] }}/delete" class="d-inline">
+          <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+        </form>
+        <a href="/students/{{ s['id'] }}/enrollments" class="btn btn-link btn-sm">Enrollments</a>
+        <a href="/progress?student_id={{ s['id'] }}" class="btn btn-link btn-sm">Progress</a>
+        <a href="/students/{{ s['id'] }}/grades" class="btn btn-link btn-sm">Grades</a>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
 {% endblock %}

--- a/templates/teachers.html
+++ b/templates/teachers.html
@@ -15,16 +15,27 @@
     <button type="submit" class="btn btn-primary">Add</button>
   </div>
 </form>
-<ul class="list-group mt-3">
-{% for t in teachers %}
-  <li class="list-group-item">
-    <a href="/teachers/{{ t['id'] }}">{{ t['first_name'] }} {{ t['last_name'] }}</a>
-    ({{ t['email'] or '' }})
-    <a href="/teachers/{{ t['id'] }}/edit" class="btn btn-secondary btn-sm ms-2">Edit</a>
-    <form method="post" action="/teachers/{{ t['id'] }}/delete" class="d-inline">
-      <button type="submit" class="btn btn-danger btn-sm">Delete</button>
-    </form>
-  </li>
-{% endfor %}
-</ul>
+<table class="table table-striped mt-3">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Email</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for t in teachers %}
+    <tr>
+      <td><a href="/teachers/{{ t['id'] }}">{{ t['first_name'] }} {{ t['last_name'] }}</a></td>
+      <td>{{ t['email'] or '' }}</td>
+      <td>
+        <a href="/teachers/{{ t['id'] }}/edit" class="btn btn-secondary btn-sm">Edit</a>
+        <form method="post" action="/teachers/{{ t['id'] }}/delete" class="d-inline">
+          <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace unordered lists in teacher and student templates with Bootstrap striped tables
- Include Name, Email and Actions columns driven by Jinja loops
- Style action links as Bootstrap buttons

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'school_db')*

------
https://chatgpt.com/codex/tasks/task_e_68c7031aa63c83249210d0ce86aa872b