### PR TITLE
Add bootstrap modals for teacher and student forms

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -21,5 +21,6 @@
 <div class="container mt-4">
     {% block content %}{% endblock %}
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/students.html
+++ b/templates/students.html
@@ -1,23 +1,38 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Students</h1>
-<form method="post" action="/students/add" class="row g-3">
-  <div class="col-md">
-    <input name="first_name" placeholder="First name" class="form-control">
+<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addStudentModal">Add</button>
+
+<div class="modal fade" id="addStudentModal" tabindex="-1" aria-labelledby="addStudentModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="/students/add">
+        <div class="modal-header">
+          <h5 class="modal-title" id="addStudentModalLabel">Add Student</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <input name="first_name" placeholder="First name" class="form-control">
+          </div>
+          <div class="mb-3">
+            <input name="last_name" placeholder="Last name" class="form-control">
+          </div>
+          <div class="mb-3">
+            <input name="student_number" placeholder="Student number" class="form-control">
+          </div>
+          <div class="mb-3">
+            <input name="email" placeholder="Email" class="form-control">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="submit" class="btn btn-primary">Add</button>
+        </div>
+      </form>
+    </div>
   </div>
-  <div class="col-md">
-    <input name="last_name" placeholder="Last name" class="form-control">
-  </div>
-  <div class="col-md">
-    <input name="student_number" placeholder="Student number" class="form-control">
-  </div>
-  <div class="col-md">
-    <input name="email" placeholder="Email" class="form-control">
-  </div>
-  <div class="col-md-auto">
-    <button type="submit" class="btn btn-primary">Add</button>
-  </div>
-</form>
+</div>
+
 <table class="table table-striped mt-3">
   <thead>
     <tr>
@@ -32,10 +47,39 @@
       <td>{{ s['first_name'] }} {{ s['last_name'] }} ({{ s['student_number'] }})</td>
       <td>{{ s['email'] }}</td>
       <td>
-        <a href="/students/{{ s['id'] }}/edit" class="btn btn-secondary btn-sm">Edit</a>
+        <button type="button" class="btn btn-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#editStudentModal-{{ s['id'] }}">Edit</button>
         <form method="post" action="/students/{{ s['id'] }}/delete" class="d-inline">
           <button type="submit" class="btn btn-danger btn-sm">Delete</button>
         </form>
+        <div class="modal fade" id="editStudentModal-{{ s['id'] }}" tabindex="-1" aria-labelledby="editStudentModalLabel-{{ s['id'] }}" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <form method="post" action="/students/{{ s['id'] }}/edit">
+                <div class="modal-header">
+                  <h5 class="modal-title" id="editStudentModalLabel-{{ s['id'] }}">Edit Student</h5>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                  <div class="mb-3">
+                    <input name="first_name" value="{{ s['first_name'] }}" class="form-control">
+                  </div>
+                  <div class="mb-3">
+                    <input name="last_name" value="{{ s['last_name'] }}" class="form-control">
+                  </div>
+                  <div class="mb-3">
+                    <input name="student_number" value="{{ s['student_number'] }}" class="form-control">
+                  </div>
+                  <div class="mb-3">
+                    <input name="email" value="{{ s['email'] }}" class="form-control">
+                  </div>
+                </div>
+                <div class="modal-footer">
+                  <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
         <a href="/students/{{ s['id'] }}/enrollments" class="btn btn-link btn-sm">Enrollments</a>
         <a href="/progress?student_id={{ s['id'] }}" class="btn btn-link btn-sm">Progress</a>
         <a href="/students/{{ s['id'] }}/grades" class="btn btn-link btn-sm">Grades</a>

--- a/templates/teachers.html
+++ b/templates/teachers.html
@@ -1,20 +1,35 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Teachers</h1>
-<form method="post" action="/teachers/add" class="row g-3">
-  <div class="col-md">
-    <input name="first_name" placeholder="First name" class="form-control">
+<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addTeacherModal">Add</button>
+
+<div class="modal fade" id="addTeacherModal" tabindex="-1" aria-labelledby="addTeacherModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="/teachers/add">
+        <div class="modal-header">
+          <h5 class="modal-title" id="addTeacherModalLabel">Add Teacher</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <input name="first_name" placeholder="First name" class="form-control">
+          </div>
+          <div class="mb-3">
+            <input name="last_name" placeholder="Last name" class="form-control">
+          </div>
+          <div class="mb-3">
+            <input name="email" placeholder="Email" class="form-control">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="submit" class="btn btn-primary">Add</button>
+        </div>
+      </form>
+    </div>
   </div>
-  <div class="col-md">
-    <input name="last_name" placeholder="Last name" class="form-control">
-  </div>
-  <div class="col-md">
-    <input name="email" placeholder="Email" class="form-control">
-  </div>
-  <div class="col-md-auto">
-    <button type="submit" class="btn btn-primary">Add</button>
-  </div>
-</form>
+</div>
+
 <table class="table table-striped mt-3">
   <thead>
     <tr>
@@ -29,10 +44,37 @@
       <td><a href="/teachers/{{ t['id'] }}">{{ t['first_name'] }} {{ t['last_name'] }}</a></td>
       <td>{{ t['email'] or '' }}</td>
       <td>
-        <a href="/teachers/{{ t['id'] }}/edit" class="btn btn-secondary btn-sm">Edit</a>
+        <button type="button" class="btn btn-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#editTeacherModal-{{ t['id'] }}">Edit</button>
         <form method="post" action="/teachers/{{ t['id'] }}/delete" class="d-inline">
           <button type="submit" class="btn btn-danger btn-sm">Delete</button>
         </form>
+
+        <div class="modal fade" id="editTeacherModal-{{ t['id'] }}" tabindex="-1" aria-labelledby="editTeacherModalLabel-{{ t['id'] }}" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <form method="post" action="/teachers/{{ t['id'] }}/edit">
+                <div class="modal-header">
+                  <h5 class="modal-title" id="editTeacherModalLabel-{{ t['id'] }}">Edit Teacher</h5>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                  <div class="mb-3">
+                    <input name="first_name" value="{{ t['first_name'] }}" class="form-control">
+                  </div>
+                  <div class="mb-3">
+                    <input name="last_name" value="{{ t['last_name'] }}" class="form-control">
+                  </div>
+                  <div class="mb-3">
+                    <input name="email" value="{{ t['email'] or '' }}" class="form-control">
+                  </div>
+                </div>
+                <div class="modal-footer">
+                  <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
       </td>
     </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- Replace inline add forms with Bootstrap modals for teachers and students
- Enable modal-based editing for individual teachers and students
- Include Bootstrap JS bundle to support modal functionality

## Testing
- `python -m pytest tests/test_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7041098bc8324a12abf263c849501