### PR TITLE
Wrap analytics charts in responsive Bootstrap cards

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -1,8 +1,30 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Analytics</h1>
-<canvas id="coursesChart" width="400" height="200"></canvas>
-<canvas id="teachersChart" width="400" height="200"></canvas>
+<div class="row">
+  <div class="col-md-6 mb-4">
+    <div class="card">
+      <div class="card-header">Popular Courses</div>
+      <div class="card-body">
+        <canvas id="coursesChart"></canvas>
+      </div>
+      <div class="card-footer text-muted">
+        Number of enrollments per course.
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6 mb-4">
+    <div class="card">
+      <div class="card-header">Popular Teachers</div>
+      <div class="card-body">
+        <canvas id="teachersChart"></canvas>
+      </div>
+      <div class="card-footer text-muted">
+        Number of students per teacher.
+      </div>
+    </div>
+  </div>
+</div>
 <script>
 async function loadCharts() {
   const coursesResp = await fetch('/api/analytics/popular-courses');


### PR DESCRIPTION
## Summary
- Display analytics charts in Bootstrap cards with headers and footers
- Use a responsive row with two `col-md-6` columns for side-by-side charts
- Add brief descriptions beneath each chart for context

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'school_db')*

------
https://chatgpt.com/codex/tasks/task_e_68c70505978483248dbd3ba31bb87d0e